### PR TITLE
Fix calling of npx

### DIFF
--- a/pyright/cli.py
+++ b/pyright/cli.py
@@ -2,7 +2,7 @@ import os
 import sys
 import logging
 import subprocess
-from typing import List, NoReturn, Union, Any
+from typing import List, NoReturn, Union, Any, Tuple
 
 from . import node
 from .utils import env_to_bool
@@ -20,15 +20,10 @@ def main(args: List[str], **kwargs: Any) -> int:
     return run(*args, **kwargs).returncode
 
 
-def run(
-    *args: str, **kwargs: Any
-) -> Union['subprocess.CompletedProcess[bytes]', 'subprocess.CompletedProcess[str]']:
-    version = os.environ.get('PYRIGHT_PYTHON_FORCE_VERSION')
-    if version is None:
-        version = node.latest('pyright')
-
-    npx = node.version('npx')
-    if npx[0] >= 7:
+def build_cmd(
+    *args: str, pyright_version: str, npx_version: Tuple[int, ...]
+) -> List[str]:
+    if npx_version[0] >= 7:
         pre_args = ['--yes']
 
         if not env_to_bool('PYRIGHT_PYTHON_VERBOSE', default=False):
@@ -39,7 +34,22 @@ def run(
     if args and pre_args:
         pre_args = (*pre_args, '--')
 
-    return node.run('npx', *pre_args, f'pyright@{version}', *args, **kwargs)
+    return ['npx', *pre_args, f'pyright@{pyright_version}', *args]
+
+
+def run(
+    *args: str, **kwargs: Any
+) -> Union['subprocess.CompletedProcess[bytes]', 'subprocess.CompletedProcess[str]']:
+    version = os.environ.get('PYRIGHT_PYTHON_FORCE_VERSION')
+    if version is None:
+        version = node.latest('pyright')
+
+    npx = node.version('npx')
+
+    target, *cmd_args = build_cmd(*args, pyright_version=version, npx_version=npx)
+    assert target == 'npx'
+
+    return node.run(target, *cmd_args, **kwargs)
 
 
 def entrypoint() -> NoReturn:

--- a/pyright/cli.py
+++ b/pyright/cli.py
@@ -31,9 +31,6 @@ def build_cmd(
     else:
         pre_args = []
 
-    if args and pre_args:
-        pre_args = (*pre_args, '--')
-
     return ['npx', *pre_args, f'pyright@{pyright_version}', *args]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,25 @@
+from typing import List, Tuple
+
+import pytest
+
+from pyright import cli
+
+
+@pytest.mark.parametrize(
+    'npx,pyright,args,expected',
+    [
+        [(1, 0), '2', [], ['npx', 'pyright@2']],
+        [(1, 0), '2', ['foo', 'bar'], ['npx', 'pyright@2', 'foo', 'bar']],
+        [(7, 0), '2', [], ['npx', '--silent', '--yes', 'pyright@2']],
+        [
+            (7, 0),
+            '2',
+            ['foo', 'bar'],
+            ['npx', '--silent', '--yes', '--', 'pyright@2', 'foo', 'bar'],
+        ],
+    ],
+)
+def test_target_version(
+    npx: Tuple[int, ...], pyright: str, args: List[str], expected: List[str]
+) -> None:
+    assert expected == cli.build_cmd(*args, pyright_version=pyright, npx_version=npx)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,7 +15,13 @@ from pyright import cli
             (7, 0),
             '2',
             ['foo', 'bar'],
-            ['npx', '--silent', '--yes', '--', 'pyright@2', 'foo', 'bar'],
+            ['npx', '--silent', '--yes', 'pyright@2', 'foo', 'bar'],
+        ],
+        [
+            (7, 0),
+            '2',
+            ['foo', '--', 'bar'],
+            ['npx', '--silent', '--yes', 'pyright@2', 'foo', '--', 'bar'],
         ],
     ],
 )


### PR DESCRIPTION
According to the [NPX documentation](https://docs.npmjs.com/cli/v8/commands/npm-exec) for the syntax we're using the `--` is not supported (or rather has no special meaning) and everything (including any `--`) after the package name will be passed on to the command.
This PR tries to fix #11 by simply dropping the injected `--`.

We also add a unit test for building the npx command.