### PR TITLE
refactor(node): Use user-specific temporary directories

### DIFF
--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -10,8 +10,7 @@ from typing import Any, NoReturn, Union
 from . import node
 
 
-TEMP_DIR = (Path(tempfile.gettempdir())
-            / f'pyright-python-langserver.{getuser()}')
+TEMP_DIR = Path(tempfile.gettempdir()) / f'pyright-python-langserver.{getuser()}'
 
 
 def main(*args: str, **kwargs: Any) -> int:

--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -3,13 +3,15 @@ import subprocess
 import sys
 import json
 import tempfile
+from getpass import getuser
 from pathlib import Path
 from typing import Any, NoReturn, Union
 
 from . import node
 
 
-TEMP_DIR = Path(tempfile.gettempdir()) / 'pyright-python-langserver'
+TEMP_DIR = (Path(tempfile.gettempdir())
+            / f'pyright-python-langserver.{getuser()}')
 
 
 def main(*args: str, **kwargs: Any) -> int:

--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -10,7 +10,16 @@ from typing import Any, NoReturn, Union
 from . import node
 
 
-TEMP_DIR = Path(tempfile.gettempdir()) / f'pyright-python-langserver.{getuser()}'
+def get_temp_dir() -> Path:
+    try:
+        suffix = f'.{getuser()}'
+    except Exception:
+        suffix = ''
+
+    return Path(tempfile.gettempdir()) / f'pyright-python-langserver{suffix}'
+
+
+TEMP_DIR = get_temp_dir()
 
 
 def main(*args: str, **kwargs: Any) -> int:

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -12,8 +12,7 @@ def get_env_dir() -> Path:
     if env_dir is not None:
         return Path(env_dir)
 
-    return (Path(tempfile.gettempdir())
-            / f'pyright-python.{getuser()}' / 'env')
+    return Path(tempfile.gettempdir()) / f'pyright-python.{getuser()}' / 'env'
 
 
 def env_to_bool(key: str, *, default: bool = False) -> bool:

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -12,7 +12,12 @@ def get_env_dir() -> Path:
     if env_dir is not None:
         return Path(env_dir)
 
-    return Path(tempfile.gettempdir()) / f'pyright-python.{getuser()}' / 'env'
+    try:
+        suffix = f'.{getuser()}'
+    except Exception:
+        suffix = ''
+
+    return Path(tempfile.gettempdir()) / f'pyright-python{suffix}' / 'env'
 
 
 def env_to_bool(key: str, *, default: bool = False) -> bool:

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+from getpass import getuser
 from pathlib import Path
 from typing import Union
 
@@ -11,7 +12,8 @@ def get_env_dir() -> Path:
     if env_dir is not None:
         return Path(env_dir)
 
-    return Path(tempfile.gettempdir()) / 'pyright-python' / 'env'
+    return (Path(tempfile.gettempdir())
+            / f'pyright-python.{getuser()}' / 'env')
 
 
 def env_to_bool(key: str, *, default: bool = False) -> bool:


### PR DESCRIPTION
In multi-user environments, the use of `/tmp/pyright-python` and `/tmp/pyright-python-langserver` can lead to conflicts. (The former can be manually overridden using `PYRIGHT_PYTHON_ENV_DIR`, but the latter is hardcoded.) This PR addresses the issue in the dumbest way possible, by including the username in the names of these two directories. `PYRIGHT_PYTHON_ENV_DIR` is still obeyed, if it is set.