### PR TITLE
feat: add support for pre-commit usage

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+-   id: pyright
+    name: pyright
+    description: 'Python command line wrapper for pyright, a static type checker'
+    entry: pyright
+    language: python
+    'types_or': [python, pyi]
+    require_serial: true
+    additional_dependencies: []
+    minimum_pre_commit_version: '2.9.2'

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ repos:
     - id: pyright
 ```
 
-To fix missing import errors add virtual environment settings in the config file:
+Pre-commit will install pyright-python in it's own virtual environment which can cause pyright to not be able to detect your installed dependencies.
+
+To fix this you can either [tell pre-coomit](https://pre-commit.com/#config-additional_dependencies) to also install hose depencies or explicitly tell pyright which virtual environment to use by updating your [pyright configuration file](https://github.com/microsoft/pyright/blob/main/docs/configuration.md):
 
 ```toml
 [tool.pyright]

--- a/README.md
+++ b/README.md
@@ -28,29 +28,27 @@ python3 -m pyright --help
 
 Pyright for Python should work exactly the same as pyright does, see the [pyright documentation](https://github.com/microsoft/pyright/blob/main/docs/getting-started.md) for details on how to make use of pyright.
 
-You can also setup pyright to run automatically before commit by setting up [pre-commit](https://pre-commit.com) and registering pyright in your .pre-commit-config.yaml.
-repos:
+### Pre-commit
+
+You can also setup pyright to run automatically before each commit by setting up [pre-commit](https://pre-commit.com) and registering pyright in your `.pre-commit-config.yaml` file
+
 ```yaml
-# ...
-- repo: https://github.com/RobertCraigie/pyright-python
-  rev: v1.1.237
-  hooks:
-  - id: pyright
+repos:
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.237
+    hooks:
+    - id: pyright
 ```
+
 To fix missing import errors add virtual environment settings in the config file:
+
 ```toml
 [tool.pyright]
-include = [
-    "src",
-    "tests",
-]
-pythonVersion = "3.9"
-typeCheckingMode = "strict"
-
-# this part
+# ...
 venvPath = "."
 venv = ".venv"
 ```
+
 ## Motivation
 
 [Pyright](https://github.com/microsoft/pyright) is written in TypeScript and requires node to be installed and is normally installed with npm, this could be a barrier for entry for some python developers as they may not have node or npm, installed on their machine, I wanted to make pyright as easy to install as any normal python package.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ python3 -m pyright --help
 
 Pyright for Python should work exactly the same as pyright does, see the [pyright documentation](https://github.com/microsoft/pyright/blob/main/docs/getting-started.md) for details on how to make use of pyright.
 
+You can also setup pyright to run automatically before commit by setting up [pre-commit](https://pre-commit.com) and registering pyright in your .pre-commit-config.yaml.
+repos:
+```yaml
+# ...
+- repo: https://github.com/RobertCraigie/pyright-python
+  rev: v1.1.237
+  hooks:
+  - id: pyright
+```
+To fix missing import errors add virtual environment settings in the config file:
+```toml
+[tool.pyright]
+include = [
+    "src",
+    "tests",
+]
+pythonVersion = "3.9"
+typeCheckingMode = "strict"
+
+# this part
+venvPath = "."
+venv = ".venv"
+```
 ## Motivation
 
 [Pyright](https://github.com/microsoft/pyright) is written in TypeScript and requires node to be installed and is normally installed with npm, this could be a barrier for entry for some python developers as they may not have node or npm, installed on their machine, I wanted to make pyright as easy to install as any normal python package.


### PR DESCRIPTION
Something is wrong with this setup, because pyright in pre-commit does not know about installed libraries and throws errors.

Closes #51