### PR TITLE
Gracefully handle keyboard interrupts

### DIFF
--- a/pyright/node.py
+++ b/pyright/node.py
@@ -122,8 +122,7 @@ def run(
             proc.terminate()
             print("Node process terminated")
             return_code = 127  # standard code for keyboard interrupt
-            stdout = None
-            stderr = None
+            stdout, stderr = proc.communicate()
         except KeyboardInterrupt as exc2:
             # If another keyboard interrupt occurred, kill the process without
             # waiting on termination but inform the user that this is unsafe.


### PR DESCRIPTION
Fixes #80 

Note: I haven't done too much testing here, other than running the provided unit-tests, and general sample run of `python -m pyright` with testing the ctrl+c behavior. Also, I've only tested this on a linux machine since I don't have any windows machine available. So I'd ask for a lot more in-depth testing before approving and merging.