### PR TITLE
fix(node): update the PATH environment variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ typeCheckingMode = "strict"
 
 reportImportCycles = false
 
+reportPrivateUsage = false
+
 # enable these for now as none of raise any
 # errors anyway
 reportCallInDefaultInitializer = true

--- a/pyright/node.py
+++ b/pyright/node.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import re
 import sys
-import pipes
 import shutil
 import logging
 import subprocess

--- a/pyright/node.py
+++ b/pyright/node.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import sys
@@ -6,7 +8,7 @@ import shutil
 import logging
 import subprocess
 from functools import lru_cache
-from typing import Dict, Tuple, Optional, Union, Any
+from typing import Dict, Mapping, Tuple, Optional, Union, Any
 from pathlib import Path
 
 from . import errors

--- a/pyright/node.py
+++ b/pyright/node.py
@@ -84,25 +84,16 @@ def run(
 ) -> Union['subprocess.CompletedProcess[bytes]', 'subprocess.CompletedProcess[str]']:
     check_target(target)
     binary = _ensure_available(target)
-    env = os.environ.copy()
+    env = kwargs.pop('env', None) or os.environ.copy()
 
     if binary.strategy == Strategy.NODEENV:
         env.update(get_env_variables())
 
-        if shutil.which('bash'):
-            activate = binary.path.parent / 'activate'
-            node_args = [
-                'bash',
-                '-c',
-                f'. {pipes.quote(str(activate))} && {" ".join([target, *args])}',
-            ]
-        else:
-            if not env_to_bool('PYRIGHT_PYTHON_IGNORE_WARNINGS', default=False):
-                print(
-                    'WARNING: nodeenv usage without access to bash, this is untested behaviour.\n'
-                )
-
-            node_args = [str(binary.path), *args]
+        # If we're using `nodeenv` to resolve the node binary then we also need
+        # to ensure that `node` is in the PATH so that any install scripts that
+        # assume it is present will work.
+        env.update(PATH=_update_path_env(env=env, target_bin=binary.path.parent))
+        node_args = [str(binary.path), *args]
     elif binary.strategy == Strategy.GLOBAL:
         node_args = [str(binary.path), *args]
     else:
@@ -167,3 +158,35 @@ def get_env_variables() -> Dict[str, Any]:
         'NPM_CONFIG_PREFIX': str(ENV_DIR),
         'npm_config_prefix': str(ENV_DIR),
     }
+
+
+def _update_path_env(
+    *,
+    env: Mapping[str, str] | None,
+    target_bin: Path,
+    sep: str = os.pathsep,
+) -> str:
+    """Returns a modified version of the `PATH` environment variable that has been updated
+    to include the location of the downloaded Node binaries.
+    """
+    if env is None:
+        env = dict(os.environ)
+
+    log.debug('Attempting to preprend %s to the PATH', target_bin)
+    assert target_bin.exists(), f'Target directory {target_bin} does not exist'
+
+    path = env.get('PATH', '') or os.environ.get('PATH', '')
+    if path:
+        log.debug('Found PATH contents: %s', path)
+
+        # handle the case where the PATH already starts with the separator (this probably shouldn't happen)
+        if path.startswith(sep):
+            path = f'{target_bin.absolute()}{path}'
+        else:
+            path = f'{target_bin.absolute()}{sep}{path}'
+    else:
+        # handle the case where there is no PATH set (unlikely / impossible to actually happen?)
+        path = str(target_bin.absolute())
+
+    log.debug('Using PATH environment variable: %s', path)
+    return path

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ import pytest
 from pytest_subprocess import FakeProcess
 
 import pyright
-from pyright.node import maybe_decode
+from pyright.utils import maybe_decode
 
 
 VERSION_REGEX = re.compile(r'pyright (?P<version>\d+\.\d+\.\d+)')

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,10 +1,14 @@
+import os
+import subprocess
 from typing import Tuple, TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 from pytest_subprocess import FakeProcess
 
 import pyright
 from pyright import node
+from pyright.utils import maybe_decode
 
 
 if TYPE_CHECKING:
@@ -55,3 +59,75 @@ def test_target_version_not_found(
     assert captured.out == ''
     assert captured.err == 'hello world\n'
     assert exc.match('Could not find version from `npx --version`, see output above')
+
+
+def test_run_env_argument(tmp_path: Path) -> None:
+    """Ensure the `run()` function can accept an `env` argument."""
+    tmp_path.joinpath('test.js').write_text("console.log(process.env.MY_ENV_VAR)")
+    proc = node.run(
+        'node',
+        'test.js',
+        env={**os.environ, 'MY_ENV_VAR': 'hello!'},
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert proc.returncode == 0
+    assert maybe_decode(proc.stdout) == 'hello!\n'
+
+
+def test_update_path_env(tmp_path: Path) -> None:
+    """The _update_path_env() function correctly appends the target binary path to the PATH environment variable"""
+    target = tmp_path / 'bin'
+    target.mkdir()
+
+    sep = os.pathsep
+
+    # known PATH separators - please update if need be
+    assert sep in {':', ';'}
+
+    # no env
+    path = node._update_path_env(env=None, target_bin=target)
+    assert path.startswith(f'{target.absolute()}{sep}')
+
+    # env without PATH
+    path = node._update_path_env(
+        env={'FOO': 'bar'},
+        target_bin=target,
+    )
+    assert path.startswith(f'{target.absolute()}{sep}')
+
+    # env with empty PATH
+    path = node._update_path_env(
+        env={'PATH': ''},
+        target_bin=target,
+    )
+    assert path.startswith(f'{target.absolute()}{sep}')
+
+    # env with set PATH without the separator postfix
+    path = node._update_path_env(
+        env={'PATH': '/foo'},
+        target_bin=target,
+    )
+    assert path == f'{target.absolute()}{sep}/foo'
+
+    # env with set PATH with the separator as a prefix
+    path = node._update_path_env(
+        env={'PATH': f'{sep}/foo'},
+        target_bin=target,
+    )
+    assert path == f'{target.absolute()}{sep}/foo'
+
+    # returned env included non PATH environment variables
+    path = node._update_path_env(
+        env={'PATH': '/foo', 'FOO': 'bar'},
+        target_bin=target,
+    )
+    assert path == f'{target.absolute()}{sep}/foo'
+
+    # accepts a custom path separator
+    path = node._update_path_env(
+        env={'PATH': '/foo'},
+        target_bin=target,
+        sep='---',
+    )
+    assert path == f'{target.absolute()}---/foo'


### PR DESCRIPTION
This PR updates our `nodeenv` handling so that we update the `PATH` environment variable to ensure that `node` and other scripts will point to our downloaded binaries. Without this, machines that don't have node installed globally already, can be broken

closes #116