### PR TITLE
feat: add support for offline usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,12 @@ By default, Pyright for Python disables npm error messages, if you want to displ
 
 ### Modify NPM Package Location
 
-By default, Pyright for Python respects the `XDG_CACHE_HOME` environment variable and otherwise defaults to `~/.cache`.
+Pyright for Python will resolve the root cache directory by checking the following environment variables, in order:
 
-If you need to use a different directory you can set the `XDG_CACHE_HOME` environment variable.
+- `PYRIGHT_PYTHON_CACHE_DIR`
+- `XDG_CACHE_HOME`
+
+If neither of them are set it defaults to `~/.cache`
 
 ### Force Node Env
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ venv = ".venv"
 
 ## How Pyright for Python Works
 
-This project works by first checking if node is in the `PATH`. If it is not, then we download node at runtime using [nodeenv](https://github.com/ekalinin/nodeenv) and then install the pyright npm package using `npx`.
+This project works by first checking if node is in the `PATH`. If it is not, then we download node at runtime using [nodeenv](https://github.com/ekalinin/nodeenv), then install the pyright npm package using `npm` and finally, run the downloaded JS with `node`.
 
 ## Automatically keeping pyright up to date
 
@@ -85,6 +85,12 @@ Set `PYRIGHT_PYTHON_FORCE_VERSION` to the desired version, e.g. `1.1.156`, `late
 
 By default, Pyright for Python disables npm error messages, if you want to display the npm error messages then set `PYRIGHT_PYTHON_VERBOSE` to any truthy value.
 
+### Modify NPM Package Location
+
+By default, Pyright for Python respects the `XDG_CACHE_HOME` environment variable and otherwise defaults to `~/.cache`.
+
+If you need to use a different directory you can set the `XDG_CACHE_HOME` environment variable.
+
 ### Force Node Env
 
 Set `PYRIGHT_PYTHON_GLOBAL_NODE` to any non-truthy value, i.e. anything apart from 1, t, on, or true.
@@ -100,7 +106,7 @@ Set `PYRIGHT_PYTHON_IGNORE_WARNINGS` to a truthy value, e.g. 1, t, on, or true.
 
 Pyright for Python will print warnings for the following case(s)
 
-- Using [nodeenv](https://github.com/ekalinin/nodeenv) without bash available
+- There is a new Pyright version available.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,6 @@ Pyright for Python will print warnings for the following case(s)
 
 - Using [nodeenv](https://github.com/ekalinin/nodeenv) without bash available
 
-### Disable NPX Version Check
-
-By default, Pyright for Python checks the version of the resolved `npx` binary, in some cases this [can cause an error](https://github.com/RobertCraigie/pyright-python/issues/56).
-
-If this is the case for you, then you can disable the version check by setting the environment variable `PYRIGHT_PYTHON_IGNORE_NPX_CHECK` to any truthy value, e.g. 1, t, on or true.
-
 ## Contributing
 
 All pull requests are welcome.

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -23,7 +23,7 @@ DEFAULT_PACKAGE_JSON: dict[str, Any] = {
 }
 
 
-def install_pyright(args: tuple[object]) -> Path:
+def install_pyright(args: tuple[object], *, quiet: bool | None) -> Path:
     """Internal helper function to install the Pyright npm package to a cache.
 
     This returns the path to the installed package.
@@ -35,7 +35,7 @@ def install_pyright(args: tuple[object]) -> Path:
     if version == 'latest':
         version = node.latest('pyright')
     else:
-        if _should_warn_version(version, args=args):
+        if _should_warn_version(version, args=args, quiet=quiet):
             print(
                 f'WARNING: there is a new pyright version available (v{version} -> v{get_latest_version()}).\n'
                 + 'Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`\n'
@@ -71,7 +71,16 @@ def install_pyright(args: tuple[object]) -> Path:
     return pkg_dir
 
 
-def _should_warn_version(version: str, args: tuple[object]) -> bool:
+def _should_warn_version(
+    version: str,
+    *,
+    args: tuple[object],
+    quiet: bool | None,
+) -> bool:
+    if quiet:
+        # This flag is set by the language server as the output must always be machine parseable
+        return False
+
     if '--outputjson' in args:
         # If this flag is set then the output must be machine parseable
         return False

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -11,7 +11,7 @@ from . import __pyright_version__, node
 from .utils import env_to_bool, get_latest_version, get_cache_dir
 
 
-ROOT_CACHE_DIR = get_cache_dir() / 'pyright-python' / 'packages'
+ROOT_CACHE_DIR = get_cache_dir() / 'pyright-python'
 DEFAULT_PACKAGE_JSON: dict[str, Any] = {
     'name': 'pyright-binaries',
     'version': '1.0.0',

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -76,9 +76,7 @@ def _should_warn_version(version: str, args: tuple[object]) -> bool:
         # If this flag is set then the output must be machine parseable
         return False
 
-    if env_to_bool('PYRIGHT_PYTHON_VERBOSE', default=False) or env_to_bool(
-        'PYRIGHT_PYTHON_IGNORE_WARNINGS', default=False
-    ):
+    if env_to_bool('PYRIGHT_PYTHON_IGNORE_WARNINGS', default=False):
         return False
 
     # NOTE: there is an edge case here where a new pyright version has been released

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -55,7 +55,7 @@ def install_pyright(args: tuple[object]) -> Path:
         # If it finds a different `package.json` file then the `pyright` package
         # will be installed there instead of our cache directory.
         if not package_json.exists():
-            package_json.write_text(json.dumps(DEFAULT_PACKAGE_JSON))
+            package_json.write_text(json.dumps(DEFAULT_PACKAGE_JSON, indent=2))
 
         silent = '--outputjson' in args
         node.run(

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+from . import __pyright_version__, node
+from .utils import env_to_bool, get_latest_version, get_cache_dir
+
+
+CACHE_DIR = get_cache_dir() / 'pyright-python'
+
+
+def install_pyright(args: tuple[object]) -> Path:
+    """Internal helper function to install the Pyright npm package to a cache.
+
+    This returns the path to the installed package.
+
+    This accepts a single argument which corresponds to the arguments given to the CLI / langserver
+    which are used to determine whether or not certain warnings / logs will be printed.
+    """
+    CACHE_DIR.mkdir(exist_ok=True, parents=True)
+
+    version = os.environ.get('PYRIGHT_PYTHON_FORCE_VERSION', __pyright_version__)
+    if version == 'latest':
+        version = node.latest('pyright')
+    else:
+        if _should_warn_version(version, args=args):
+            print(
+                f'WARNING: there is a new pyright version available (v{__pyright_version__} -> v{get_latest_version()}).\n'
+                + 'Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`\n'
+            )
+
+    pkg_dir = CACHE_DIR / 'node_modules' / 'pyright'
+    current_version = node.get_pkg_version(pkg_dir / 'package.json')
+
+    if current_version is None or current_version != version:
+        silent = '--outputjson' in args
+        node.run(
+            'npm',
+            'install',
+            f'pyright@{version}',
+            cwd=str(CACHE_DIR),
+            check=True,
+            stdout=subprocess.PIPE if silent else sys.stdout,
+            stderr=subprocess.PIPE if silent else sys.stderr,
+        )
+
+    return pkg_dir
+
+
+def _should_warn_version(version: str, args: tuple[object]) -> bool:
+    if '--outputjson' in args:
+        # If this flag is set then the output must be machine parseable
+        return False
+
+    if env_to_bool('PYRIGHT_PYTHON_VERBOSE', default=False) or env_to_bool(
+        'PYRIGHT_PYTHON_IGNORE_WARNINGS', default=False
+    ):
+        return False
+
+    # NOTE: there is an edge case here where a new pyright version has been released
+    # but we haven't made a new pyright-python release yet and the user has set
+    # PYRIGHT_PYTHON_FORCE_VERSION to the new pyright version.
+    # This should rarely happen as we make new releases very frequently after
+    # pyright does. Also in order to correctly compare versions we would need an additional
+    # dependency. As such this is an acceptable bug.
+    latest = get_latest_version()
+    return latest is not None and latest != version
+
+

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -11,7 +11,7 @@ from . import __pyright_version__, node
 from .utils import env_to_bool, get_latest_version, get_cache_dir
 
 
-ROOT_CACHE_DIR = get_cache_dir() / 'pyright-python'
+ROOT_CACHE_DIR = get_cache_dir() / 'pyright-python' / 'packages'
 DEFAULT_PACKAGE_JSON: dict[str, Any] = {
     'name': 'pyright-binaries',
     'version': '1.0.0',

--- a/pyright/cli.py
+++ b/pyright/cli.py
@@ -1,11 +1,10 @@
-import os
 import sys
 import logging
 import subprocess
-from typing import List, NoReturn, Union, Tuple, Any
+from typing import List, NoReturn, Union, Any
 
-from . import __pyright_version__, node
-from .utils import env_to_bool, get_latest_version, get_cache_dir
+from . import node
+from ._utils import install_pyright
 
 
 __all__ = (
@@ -20,64 +19,15 @@ def main(args: List[str], **kwargs: Any) -> int:
     return run(*args, **kwargs).returncode
 
 
-CACHE_DIR = get_cache_dir() / 'pyright-python'
-
-
 def run(
     *args: str, **kwargs: Any
 ) -> Union['subprocess.CompletedProcess[bytes]', 'subprocess.CompletedProcess[str]']:
-    CACHE_DIR.mkdir(exist_ok=True, parents=True)
-
-    version = os.environ.get('PYRIGHT_PYTHON_FORCE_VERSION', __pyright_version__)
-    if version == 'latest':
-        version = node.latest('pyright')
-    else:
-        if _should_warn_version(version, args=args):
-            print(
-                f'WARNING: there is a new pyright version available (v{__pyright_version__} -> v{get_latest_version()}).\n'
-                + 'Please install the new version or set PYRIGHT_PYTHON_FORCE_VERSION to `latest`\n'
-            )
-
-    pkg_dir = CACHE_DIR / 'node_modules' / 'pyright'
-    current_version = node.get_pkg_version(pkg_dir / 'package.json')
-
-    if current_version is None or current_version != version:
-        silent = '--outputjson' in args
-        node.run(
-            'npm',
-            'install',
-            f'pyright@{version}',
-            cwd=str(CACHE_DIR),
-            check=True,
-            stdout=subprocess.PIPE if silent else sys.stdout,
-            stderr=subprocess.PIPE if silent else sys.stderr,
-        )
-
+    pkg_dir = install_pyright(args)
     script = pkg_dir / 'index.js'
     if not script.exists():
         raise RuntimeError(f'Expected CLI entrypoint: {script} to exist')
 
-    return node.run('node', str(script), '--', *args, **kwargs)
-
-
-def _should_warn_version(version: str, args: Tuple[object]) -> bool:
-    if '--outputjson' in args:
-        # If this flag is set then the output must be machine parseable
-        return False
-
-    if env_to_bool('PYRIGHT_PYTHON_VERBOSE', default=False) or env_to_bool(
-        'PYRIGHT_PYTHON_IGNORE_WARNINGS', default=False
-    ):
-        return False
-
-    # NOTE: there is an edge case here where a new pyright version has been released
-    # but we haven't made a new pyright-python release yet and the user has set
-    # PYRIGHT_PYTHON_FORCE_VERSION to the new pyright version.
-    # This should rarely happen as we make new releases very frequently after
-    # pyright does. Also in order to correctly compare versions we would need an additional
-    # dependency. As such this is an acceptable bug.
-    latest = get_latest_version()
-    return latest is not None and latest != version
+    return node.run('node', str(script),  *args, **kwargs)
 
 
 def entrypoint() -> NoReturn:

--- a/pyright/cli.py
+++ b/pyright/cli.py
@@ -22,7 +22,7 @@ def main(args: List[str], **kwargs: Any) -> int:
 def run(
     *args: str, **kwargs: Any
 ) -> Union['subprocess.CompletedProcess[bytes]', 'subprocess.CompletedProcess[str]']:
-    pkg_dir = install_pyright(args)
+    pkg_dir = install_pyright(args, quiet=None)
     script = pkg_dir / 'index.js'
     if not script.exists():
         raise RuntimeError(f'Expected CLI entrypoint: {script} to exist')

--- a/pyright/cli.py
+++ b/pyright/cli.py
@@ -27,7 +27,7 @@ def run(
     if not script.exists():
         raise RuntimeError(f'Expected CLI entrypoint: {script} to exist')
 
-    return node.run('node', str(script),  *args, **kwargs)
+    return node.run('node', str(script), *args, **kwargs)
 
 
 def entrypoint() -> NoReturn:

--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -16,7 +16,7 @@ def run(
     *args: str,
     **kwargs: Any,
 ) -> subprocess.CompletedProcess[bytes] | subprocess.CompletedProcess[str]:
-    pkg_dir = install_pyright(args)
+    pkg_dir = install_pyright(args, quiet=True)
     binary = pkg_dir / 'langserver.index.js'
     if not binary.exists():
         raise RuntimeError(f'Expected language server entrypoint: {binary} to exist')

--- a/pyright/node.py
+++ b/pyright/node.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import sys
+import json
 import shutil
 import logging
 import platform
@@ -169,6 +170,24 @@ def get_env_variables() -> Dict[str, Any]:
         'NPM_CONFIG_PREFIX': str(ENV_DIR),
         'npm_config_prefix': str(ENV_DIR),
     }
+
+
+def get_pkg_version(pkg: Path) -> str | None:
+    """Given a path to a `package.json` file, parse it and returns the `version` property
+
+    Returns `None` if the version could not be resolved for any reason.
+    """
+    if not pkg.exists():
+        return None
+
+    try:
+        data = json.loads(pkg.read_text())
+    except Exception:
+        # TODO: test this
+        log.debug('Ignoring error while reading/parsing the %s file', pkg, exc_info=True)
+        return None
+    
+    return data.get('version')
 
 
 def _update_path_env(

--- a/pyright/node.py
+++ b/pyright/node.py
@@ -184,9 +184,11 @@ def get_pkg_version(pkg: Path) -> str | None:
         data = json.loads(pkg.read_text())
     except Exception:
         # TODO: test this
-        log.debug('Ignoring error while reading/parsing the %s file', pkg, exc_info=True)
+        log.debug(
+            'Ignoring error while reading/parsing the %s file', pkg, exc_info=True
+        )
         return None
-    
+
     return data.get('version')
 
 

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -34,7 +34,7 @@ def get_cache_dir() -> Path:
     xdg = os.environ.get('XDG_CACHE_HOME')
     if xdg is not None:
         return Path(xdg)
-    
+
     return Path.home() / '.cache'
 
 

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -16,18 +16,15 @@ log: logging.Logger = logging.getLogger(__name__)
 
 
 def get_env_dir() -> Path:
-    """Returns the directory that contains the nodeenv"""
+    """Returns the directory that contains the nodeenv.
+
+    This first respects the `PYRIGHT_PYTHON_ENV_DIR` variable and delegates to `get_cache_dir()` otherwise.
+    """
     env_dir = os.environ.get('PYRIGHT_PYTHON_ENV_DIR')
     if env_dir is not None:
         return Path(env_dir)
 
-    try:
-        suffix = f'.{getuser()}'
-    except Exception:
-        suffix = ''
-
-    return Path(tempfile.gettempdir()) / f'pyright-python{suffix}' / 'env'
-
+    return get_cache_dir()
 
 def get_cache_dir() -> Path:
     """Locate a user's cache directory, respects the XDG environment if present, otherwise defaults to `~/.cache`"""

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -22,7 +22,7 @@ def get_env_dir() -> Path:
     if env_dir is not None:
         return Path(env_dir)
 
-    return get_cache_dir()
+    return get_cache_dir() / 'pyright-python' / 'nodeenv'
 
 
 def get_cache_dir() -> Path:

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -1,10 +1,8 @@
 import os
 import sys
 import logging
-import tempfile
 import platform
 from pathlib import Path
-from getpass import getuser
 from functools import lru_cache
 from typing import Union, Optional
 

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -26,6 +26,10 @@ def get_env_dir() -> Path:
 
 def get_cache_dir() -> Path:
     """Locate a user's cache directory, respects the XDG environment if present, otherwise defaults to `~/.cache`"""
+    custom = os.environ.get('PYRIGHT_PYTHON_CACHE_DIR')
+    if custom is not None:
+        return Path(custom)
+
     xdg = os.environ.get('XDG_CACHE_HOME')
     if xdg is not None:
         return Path(xdg)

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -7,8 +7,6 @@ from functools import lru_cache
 from typing import Union, Optional
 
 from . import _mureq as mureq
-from ._utils import get_tmp_path_suffix
-
 
 PYPI_API_URL: str = 'https://pypi.org/pypi/pyright/json'
 log: logging.Logger = logging.getLogger(__name__)

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -29,6 +29,15 @@ def get_env_dir() -> Path:
     return Path(tempfile.gettempdir()) / f'pyright-python{suffix}' / 'env'
 
 
+def get_cache_dir() -> Path:
+    """Locate a user's cache directory, respects the XDG environment if present, otherwise defaults to `~/.cache`"""
+    xdg = os.environ.get('XDG_CACHE_HOME')
+    if xdg is not None:
+        return Path(xdg)
+    
+    return Path.home() / '.cache'
+
+
 def get_bin_dir(*, env_dir: Path) -> Path:
     name = platform.system().lower()
     if name == 'windows':

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -26,6 +26,7 @@ def get_env_dir() -> Path:
 
     return get_cache_dir()
 
+
 def get_cache_dir() -> Path:
     """Locate a user's cache directory, respects the XDG environment if present, otherwise defaults to `~/.cache`"""
     xdg = os.environ.get('XDG_CACHE_HOME')

--- a/tests/test_langserver.py
+++ b/tests/test_langserver.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 import subprocess
@@ -46,4 +47,5 @@ def test_only_json_output() -> None:
     assert proc.stdout is not None
 
     stdout = proc.stdout.read().decode('utf-8')
-    assert stdout == ''
+    for line in stdout.splitlines():
+        json.loads(line)

--- a/tests/test_langserver.py
+++ b/tests/test_langserver.py
@@ -1,4 +1,5 @@
 import os
+import time
 import subprocess
 
 
@@ -31,3 +32,18 @@ def test_user_special_characters() -> None:
     assert proc.returncode == 1
     output = proc.stdout.decode('utf-8')
     assert 'Connection input stream is not set' in output
+
+
+def test_only_json_output() -> None:
+    """The language server should only output valid JSON"""
+    proc = subprocess.Popen(
+        ['pyright-langserver', '--stdio'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    time.sleep(2)
+    proc.kill()
+    assert proc.stdout is not None
+
+    stdout = proc.stdout.read().decode('utf-8')
+    assert stdout == ''

--- a/tests/test_langserver.py
+++ b/tests/test_langserver.py
@@ -1,6 +1,4 @@
-import json
 import os
-import time
 import subprocess
 
 
@@ -33,22 +31,3 @@ def test_user_special_characters() -> None:
     assert proc.returncode == 1
     output = proc.stdout.decode('utf-8')
     assert 'Connection input stream is not set' in output
-
-
-def test_only_json_output() -> None:
-    """The language server should only output valid JSON"""
-    proc = subprocess.Popen(
-        ['pyright-langserver', '--stdio'],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    time.sleep(2)
-    proc.kill()
-    assert proc.stdout is not None
-
-    stdout = proc.stdout.read().decode('utf-8')
-    for line in stdout.splitlines():
-        # I'm not sure why there is a Content-Length line output sometimes.
-        # It doesn't seem to be something we're outputting anywhere...
-        if line and not line.startswith('Content-Length:'):
-            json.loads(line)

--- a/tests/test_langserver.py
+++ b/tests/test_langserver.py
@@ -50,5 +50,5 @@ def test_only_json_output() -> None:
     for line in stdout.splitlines():
         # I'm not sure why there is a Content-Length line output sometimes.
         # It doesn't seem to be something we're outputting anywhere...
-        if not line.startswith('Content-Length:'):
+        if line and not line.startswith('Content-Length:'):
             json.loads(line)

--- a/tests/test_langserver.py
+++ b/tests/test_langserver.py
@@ -48,4 +48,7 @@ def test_only_json_output() -> None:
 
     stdout = proc.stdout.read().decode('utf-8')
     for line in stdout.splitlines():
-        json.loads(line)
+        # I'm not sure why there is a Content-Length line output sometimes.
+        # It doesn't seem to be something we're outputting anywhere...
+        if not line.startswith('Content-Length:'):
+            json.loads(line)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,7 +173,7 @@ def test_package_json_in_parent_dir(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     cache_dir = tmp_path / 'foo' / 'bar'
     cache_dir.mkdir(exist_ok=True, parents=True)
 
-    monkeypatch.setenv('XDG_CACHE_HOME', str(cache_dir))
+    monkeypatch.setenv('PYRIGHT_PYTHON_CACHE_DIR', str(cache_dir))
 
     proc = subprocess.run(
         [sys.executable, '-m', 'pyright', '--version'],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,7 +154,7 @@ def test_package_json_in_parent_dir(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     tmp_path.joinpath('package.json').write_text('{"name": "another package.json"}')
 
     cache_dir = tmp_path / 'foo' / 'bar'
-    cache_dir.mkdir(exist_ok=True)
+    cache_dir.mkdir(exist_ok=True, parents=True)
 
     monkeypatch.setenv('XDG_CACHE_HOME', str(cache_dir))
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,9 +6,6 @@ import subprocess
 from pathlib import Path
 from packaging import version
 
-import pytest
-from pytest_subprocess import FakeProcess
-
 import pyright
 from pyright.utils import maybe_decode
 
@@ -145,18 +142,3 @@ def test_ignore_warnings_config_no_warning() -> None:
     output = proc.stdout.decode('utf-8')
     assert 'WARNING: there is a new pyright version available' not in output
 
-
-def test_ignoring_version_check(
-    npx: str,
-    fake_process: FakeProcess,
-) -> None:
-    fake_process.register_subprocess(
-        [npx, "--version"], stdout='hello world'
-    )  # pyright: reportUnknownMemberType=false
-    fake_process.allow_unregistered(True)
-
-    with pytest.raises(pyright.errors.VersionCheckFailed):
-        pyright.run('--help', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-
-    os.environ['PYRIGHT_PYTHON_IGNORE_NPX_CHECK'] = '1'
-    pyright.run('--help', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 import json
+import platform
 import subprocess
 from pathlib import Path
 from packaging import version
@@ -168,6 +169,10 @@ def test_package_json_in_parent_dir(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     """The CLI can be installed successfully when there is a `package.json` file
     in a parent directory.
     """
+    if platform.system() == 'Windows':
+        # hack to avoid WinError 206
+        tmp_path = tmp_path.parent.parent / 'abc'
+
     tmp_path.joinpath('package.json').write_text('{"name": "another package.json"}')
 
     cache_dir = tmp_path / 'foo' / 'bar'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -173,6 +173,7 @@ def test_package_json_in_parent_dir(tmp_path: Path, monkeypatch: MonkeyPatch) ->
         # hack to avoid WinError 206
         tmp_path = tmp_path.parent.parent / 'abc'
 
+    tmp_path.mkdir(exist_ok=True, parents=True)
     tmp_path.joinpath('package.json').write_text('{"name": "another package.json"}')
 
     cache_dir = tmp_path / 'foo' / 'bar'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -154,6 +154,7 @@ def test_package_json_in_parent_dir(tmp_path: Path, monkeypatch: MonkeyPatch) ->
     tmp_path.joinpath('package.json').write_text('{"name": "another package.json"}')
 
     cache_dir = tmp_path / 'foo' / 'bar'
+    cache_dir.mkdir(exist_ok=True)
 
     monkeypatch.setenv('XDG_CACHE_HOME', str(cache_dir))
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,10 @@ from packaging import version
 from typing import TYPE_CHECKING
 
 import pyright
+from pyright import __pyright_version__
 from pyright.utils import maybe_decode
+
+from tests.utils import assert_matches
 
 if TYPE_CHECKING:
     from _pytest.monkeypatch import MonkeyPatch
@@ -26,9 +29,8 @@ def test_module_invocation() -> None:
         stdout=subprocess.PIPE,
     )
     assert proc.returncode == 0
-    output = proc.stdout.decode('utf-8')
-    match = VERSION_REGEX.match(output)
-    assert match is not None
+    match = assert_matches(VERSION_REGEX, proc.stdout.decode('utf-8'))
+    assert match.group(1) == __pyright_version__
 
 
 def test_module_invocation_version() -> None:
@@ -39,9 +41,7 @@ def test_module_invocation_version() -> None:
         env=dict(os.environ, PYRIGHT_PYTHON_FORCE_VERSION='1.1.223'),
     )
     assert proc.returncode == 0
-    output = proc.stdout.decode('utf-8')
-    match = VERSION_REGEX.match(output)
-    assert match is not None
+    match = assert_matches(VERSION_REGEX, proc.stdout.decode('utf-8'))
     assert match.group(1) == '1.1.223'
 
 
@@ -53,10 +53,8 @@ def test_module_invocation_latest_version() -> None:
         env=dict(os.environ, PYRIGHT_PYTHON_FORCE_VERSION='latest'),
     )
     assert proc.returncode == 0
-    output = proc.stdout.decode('utf-8')
-    match = VERSION_REGEX.match(output)
-    assert match is not None
-    assert version.parse(match.group(1)) >= version.parse(pyright.__pyright_version__)
+    match = assert_matches(VERSION_REGEX, proc.stdout.decode('utf-8'))
+    assert version.parse(match.group(1)) >= version.parse(__pyright_version__)
 
 
 def test_entry_point() -> None:
@@ -67,8 +65,8 @@ def test_entry_point() -> None:
     )
     assert proc.returncode == 0
     output = proc.stdout.decode('utf-8')
-    match = VERSION_REGEX.match(output)
-    assert match is not None
+    match = assert_matches(VERSION_REGEX, output)
+    assert match.group(1) == __pyright_version__
 
 
 def test_long_arguments(tmp_path: Path) -> None:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import re
+
+
+def assert_matches(pattern: re.Pattern[str], contents: str) -> re.Match[str]:
+    match = pattern.match(contents)
+    if match is None:
+        raise ValueError(f'Pattern, {pattern}, did not match input: {contents}')
+
+    return match

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,7 @@ import re
 
 
 def assert_matches(pattern: re.Pattern[str], contents: str) -> re.Match[str]:
-    match = pattern.match(contents)
+    match = pattern.search(contents)
     if match is None:
         raise ValueError(f'Pattern, {pattern}, did not match input: {contents}')
 


### PR DESCRIPTION
This PR adds support for running Pyright with no internet access *after* the first initial run, so that the npm package can be cached.

TODO:
- [x] Use the same cache directory for storing `nodeenv` too
- [x] Share install logic with langserver
- [x] Safeguard against `package.json` files in weird places
- [ ] Add tests to the langserver to ensure there isn't any output