### PR TITLE
fix(langserver): protect against npm installing packages elsewhere

### DIFF
--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -44,6 +44,7 @@ def run(
 
     # TODO: use the same install location as the pyright CLI
     if current_version is None or current_version != version:
+        node.run('npm', 'init', "-y", cwd=str(TEMP_DIR), check=True)
         node.run('npm', 'install', f'pyright@{version}', cwd=str(TEMP_DIR), check=True)
 
     binary = TEMP_DIR / 'node_modules' / 'pyright' / 'langserver.index.js'


### PR DESCRIPTION
That raises an exception because langserver.index.js does not exist in expected location.

npm init solves that

fixes #138