### PR TITLE
fix: hash usernames to avoid special character clashes

### DIFF
--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -8,4 +8,3 @@ def get_tmp_path_suffix() -> str:
         return ''
 
     return f'.{hash(user)}'
-

--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -1,0 +1,11 @@
+from getpass import getuser
+
+
+def get_tmp_path_suffix() -> str:
+    try:
+        user = getuser()
+    except Exception:
+        return ''
+
+    return f'.{hash(user)}'
+

--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -3,20 +3,15 @@ import subprocess
 import sys
 import json
 import tempfile
-from getpass import getuser
 from pathlib import Path
 from typing import Any, NoReturn, Union
 
 from . import node, __pyright_version__
+from ._utils import get_tmp_path_suffix
 
 
 def get_temp_dir() -> Path:
-    try:
-        suffix = f'.{getuser()}'
-    except Exception:
-        suffix = ''
-
-    return Path(tempfile.gettempdir()) / f'pyright-python-langserver{suffix}'
+    return Path(tempfile.gettempdir()) / f'pyright-python-langserver{get_tmp_path_suffix()}'
 
 
 TEMP_DIR = get_temp_dir()

--- a/pyright/langserver.py
+++ b/pyright/langserver.py
@@ -11,7 +11,10 @@ from ._utils import get_tmp_path_suffix
 
 
 def get_temp_dir() -> Path:
-    return Path(tempfile.gettempdir()) / f'pyright-python-langserver{get_tmp_path_suffix()}'
+    return (
+        Path(tempfile.gettempdir())
+        / f'pyright-python-langserver{get_tmp_path_suffix()}'
+    )
 
 
 TEMP_DIR = get_temp_dir()

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -21,7 +21,9 @@ def get_env_dir() -> Path:
     if env_dir is not None:
         return Path(env_dir)
 
-    return Path(tempfile.gettempdir()) / f'pyright-python{get_tmp_path_suffix()}' / 'env'
+    return (
+        Path(tempfile.gettempdir()) / f'pyright-python{get_tmp_path_suffix()}' / 'env'
+    )
 
 
 def get_bin_dir(*, env_dir: Path) -> Path:

--- a/pyright/utils.py
+++ b/pyright/utils.py
@@ -4,11 +4,11 @@ import logging
 import tempfile
 import platform
 from pathlib import Path
-from getpass import getuser
 from functools import lru_cache
 from typing import Union, Optional
 
 from . import _mureq as mureq
+from ._utils import get_tmp_path_suffix
 
 
 PYPI_API_URL: str = 'https://pypi.org/pypi/pyright/json'
@@ -21,12 +21,7 @@ def get_env_dir() -> Path:
     if env_dir is not None:
         return Path(env_dir)
 
-    try:
-        suffix = f'.{getuser()}'
-    except Exception:
-        suffix = ''
-
-    return Path(tempfile.gettempdir()) / f'pyright-python{suffix}' / 'env'
+    return Path(tempfile.gettempdir()) / f'pyright-python{get_tmp_path_suffix()}' / 'env'
 
 
 def get_bin_dir(*, env_dir: Path) -> Path:

--- a/tests/test_langserver.py
+++ b/tests/test_langserver.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 
@@ -10,6 +11,22 @@ def test_entry_point() -> None:
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
+    )
+    assert proc.returncode == 1
+    output = proc.stdout.decode('utf-8')
+    assert 'Connection input stream is not set' in output
+
+
+def test_user_special_characters() -> None:
+    proc = subprocess.run(
+        ['pyright-langserver'],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env={
+            **os.environ,
+            'LOGNAME': 'alice@example.com',
+        },
     )
     assert proc.returncode == 1
     output = proc.stdout.decode('utf-8')

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -11,6 +11,7 @@ from pytest_subprocess import FakeProcess
 
 import pyright
 from pyright.utils import maybe_decode
+from pyright import __pyright_version__
 
 
 VERSION_REGEX = re.compile(r'pyright (?P<version>\d+\.\d+\.\d+)')
@@ -160,3 +161,19 @@ def test_ignoring_version_check(
 
     os.environ['PYRIGHT_PYTHON_IGNORE_NPX_CHECK'] = '1'
     pyright.run('--help', stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
+def test_user_special_characters() -> None:
+    proc = subprocess.run(
+        [sys.executable, '-m', 'pyright', '--version'],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        env={
+            **os.environ,
+            'LOGNAME': 'alice@example.com',
+        },
+    )
+    assert proc.returncode == 0
+    output = proc.stdout.decode('utf-8')
+    assert str(__pyright_version__) in output


### PR DESCRIPTION
This PR ensures we hash usernames instead of naively including them in the file path which can lead to issues due to special characters.

I don't think there's any value in stripping special characters as this path is not intended to be user facing and it *could* lead to clashes even though that is incredibly unlikely.

If you're debugging an issue relating to this directory then you can turn on debug logs to see which directory we're using.

closes #146