### PR TITLE
Fix get_tmp_path_suffix - hash is randomized on Python 3+

### DIFF
--- a/pyright/_utils.py
+++ b/pyright/_utils.py
@@ -1,4 +1,5 @@
 from getpass import getuser
+import hashlib
 
 
 def get_tmp_path_suffix() -> str:
@@ -7,4 +8,4 @@ def get_tmp_path_suffix() -> str:
     except Exception:
         return ''
 
-    return f'.{hash(user)}'
+    return f'.{hashlib.md5(user.encode()).hexdigest()}'


### PR DESCRIPTION
Closes #153