### PR TITLE
feat(cli): allow custom node versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If neither of them are set it defaults to `~/.cache`
 
 Set `PYRIGHT_PYTHON_GLOBAL_NODE` to any non-truthy value, i.e. anything apart from 1, t, on, or true.
 e.g. `off`
+You can optionnaly choose the version of node used by setting `PYRIGHT_PYTHON_NODE_VERSION` to the desired version
 
 ### Modify Node Env Location
 

--- a/pyright/node.py
+++ b/pyright/node.py
@@ -22,6 +22,7 @@ log: logging.Logger = logging.getLogger(__name__)
 ENV_DIR: Path = get_env_dir()
 BINARIES_DIR: Path = get_bin_dir(env_dir=ENV_DIR)
 USE_GLOBAL_NODE = env_to_bool('PYRIGHT_PYTHON_GLOBAL_NODE', default=True)
+NODE_VERSION = os.environ.get('PYRIGHT_PYTHON_NODE_VERSION', default=None)
 VERSION_RE = re.compile(r'\d+\.\d+\.\d+')
 
 
@@ -57,7 +58,7 @@ def _ensure_node_env(target: Target) -> Path:
 
     log.debug('Using %s path for binary', path)
 
-    if path.exists():
+    if path.exists() and not NODE_VERSION:
         log.debug('Binary at %s exists, skipping nodeenv installation', path)
     else:
         log.debug('Installing nodeenv as a binary at %s could not be found', path)
@@ -86,7 +87,11 @@ def _get_global_binary(target: Target) -> Optional[Path]:
 
 def _install_node_env() -> None:
     log.debug('Installing nodeenv to %s', ENV_DIR)
-    args = [sys.executable, '-m', 'nodeenv', str(ENV_DIR)]
+    args = [sys.executable, '-m', 'nodeenv']
+    if NODE_VERSION:
+        log.debug(f"Using user specified node version: {NODE_VERSION}")
+        args += ["--node", NODE_VERSION, "--force"]
+    args.append(str(ENV_DIR))
     log.debug('Running command with args: %s', args)
     subprocess.run(args, check=True)
 

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -77,8 +77,8 @@ def test_run_env_argument(tmp_path: Path) -> None:
 
 @mock.patch('pyright.node.NODE_VERSION', "13.1.0")
 @mock.patch('pyright.node.USE_GLOBAL_NODE', False)
-def test_node_version_env(tmp_path: Path) -> None:
-    """Ensure the `run()` function can accept an `env` argument."""
+def test_node_version_env() -> None:
+    """Ensure the custom version is respected."""
     proc = node.run(
         'node',
         '--version',

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 from typing import Tuple, TYPE_CHECKING
 from pathlib import Path
-
+from unittest import mock
 import pytest
 from pytest_subprocess import FakeProcess
 
@@ -74,6 +74,19 @@ def test_run_env_argument(tmp_path: Path) -> None:
     assert proc.returncode == 0
     assert maybe_decode(proc.stdout) == 'hello!\n'
 
+
+@mock.patch('pyright.node.NODE_VERSION',  "13.1.0")
+@mock.patch('pyright.node.USE_GLOBAL_NODE',  False)
+def test_node_version_env(tmp_path: Path) -> None:
+    """Ensure the `run()` function can accept an `env` argument."""
+    proc = node.run(
+        'node',
+        '--version',
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert proc.returncode == 0
+    assert maybe_decode(proc.stdout) == 'v13.1.0\n'
 
 def test_update_path_env(tmp_path: Path) -> None:
     """The _update_path_env() function correctly appends the target binary path to the PATH environment variable"""

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -75,8 +75,8 @@ def test_run_env_argument(tmp_path: Path) -> None:
     assert maybe_decode(proc.stdout) == 'hello!\n'
 
 
-@mock.patch('pyright.node.NODE_VERSION',  "13.1.0")
-@mock.patch('pyright.node.USE_GLOBAL_NODE',  False)
+@mock.patch('pyright.node.NODE_VERSION', "13.1.0")
+@mock.patch('pyright.node.USE_GLOBAL_NODE', False)
 def test_node_version_env(tmp_path: Path) -> None:
     """Ensure the `run()` function can accept an `env` argument."""
     proc = node.run(
@@ -86,7 +86,8 @@ def test_node_version_env(tmp_path: Path) -> None:
         stderr=subprocess.STDOUT,
     )
     assert proc.returncode == 0
-    assert maybe_decode(proc.stdout) == 'v13.1.0\n'
+    assert maybe_decode(proc.stdout).strip() == 'v13.1.0'
+
 
 def test_update_path_env(tmp_path: Path) -> None:
     """The _update_path_env() function correctly appends the target binary path to the PATH environment variable"""


### PR DESCRIPTION
Prebuilt default version of node does not work my company's CI and this allowed to use an older version that does work.

The solution is to add a new environment variable that controls the version