### PR TITLE
chore(ci): remove invalid reviewers

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -47,7 +47,4 @@ jobs:
             [1]: https://github.com/peter-evans/create-pull-request
           labels: |
             automated pr
-          team-reviewers: |
-            owners
-            maintainers
           draft: false


### PR DESCRIPTION
The automated GH Actions release watcher job ["errors"](https://github.com/RobertCraigie/pyright-python/actions/runs/13538366877) when creating the PR (though still creates it) because:

> Reviews may only be requested from collaborators. One or more of the teams you specified is not a collaborator of the RobertCraigie/pyright-python repository.

The job tries to add two teams as reviewers, but they don't seem to exist (at least not both of them). This PR removes the reviewers.
